### PR TITLE
Minor fix missing charset delaration in templates/layout

### DIFF
--- a/lib/images_gallery/templates/layout.html.erb
+++ b/lib/images_gallery/templates/layout.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title><%= title %></title>
     <style type="text/css">
       html, body {


### PR DESCRIPTION
The issue was preventing HTML5 validation.
See https://validator.w3.org/nu
and https://jigsaw.w3.org/css-validator/validator

Fixes #8
Then bump to [**v1.0.0**](https://github.com/gonzalo-bulnes/kata-images_gallery_generator/milestones/v1.0.0).